### PR TITLE
Fix translate for "粉红"（消歧义）

### DIFF
--- a/words.html
+++ b/words.html
@@ -247,7 +247,7 @@ which, uh, could be worse!
 </p>
 
 <p id="character_all_c">
-<b>万年小粉红：</b>
+<b>圣母白莲花：</b>
 我们大家做朋友吧！ &lt;3
 </p>
 
@@ -382,7 +382,7 @@ which, uh, could be worse!
 
 <p id="evo_1">
 我们开始先用这些玩家来进行比赛：
-<span class="all_c">十五个万年小粉红</span>，
+<span class="all_c">十五个圣母白莲花</span>，
 <span class="all_d">五个千年老油条</span>，还有
 <span class="tft">五个复读机</span>.
 （我们现在暂时先把<span class="grudge">黑帮老铁</span>和<span class="prober">福尔摩星儿</span>放一边）
@@ -392,10 +392,10 @@ which, uh, could be worse!
 </p>
 
 <p id="evo_2_all_c">
-有道理，<span class="all_c">万年小粉红</span>人多力量大嘛...
+有道理，<span class="all_c">圣母白莲花</span>人多力量大嘛...
 </p>
 <p id="evo_2_all_d">
-有道理，<span class="all_d">千年老油条</span> 有这么多<span class="all_c">万年小粉红</span>可以取剥削...
+有道理，<span class="all_d">千年老油条</span> 有这么多<span class="all_c">圣母白莲花</span>可以取剥削...
 </p>
 <p id="evo_2_tft">
 有道理，<span class="tft">复读机</span>刚刚就赢了嘛，这次怎么会输呢？...
@@ -882,14 +882,14 @@ p.s: 想尝试更多的边玩边学小游戏吗？<br>
 </span>
 </p>
 
-<p id="label_all_c">万年小粉红</p>
+<p id="label_all_c">圣母白莲花</p>
 <p id="label_short_all_c">
-万年小粉红
+圣母白莲花
 </p>
 <p id="icon_all_c">
 <span class="all_c">
 	<span class="icon"></span>
-	<span class="icon_label">万年小粉红</span>
+	<span class="icon_label">圣母白莲花</span>
 </span>
 </p>
 

--- a/words.html
+++ b/words.html
@@ -415,29 +415,29 @@ which, uh, could be worse!
 </p>
 
 <p id="evo_3_all_c">
-哎呀，<span class="all_c">小粉红</span>被
+哎呀，<span class="all_c">圣母</span>被
 <span class="all_d">老油条</span>给吃了，现在场上还剩十个。
 </p>
 <p id="evo_3_all_d">
 好吧，你赢了！这次<span class="all_d">老油条</span>获得了胜利，数量增加了五个。
 </p>
 <p id="evo_3_tft">
-哎呀，<span class="tft">复读机</span>没赢——不过至少比<span class="all_c">小粉红</span>强一点，他们都被<span class="all_d">老油条</span>给吃了五个了。
+哎呀，<span class="tft">复读机</span>没赢——不过至少比<span class="all_c">圣母</span>强一点，他们都被<span class="all_d">老油条</span>给吃了五个了。
 </p>
 <p id="evo_3">
 不过，我们再多玩几场试试...
 </p>
 
 <p id="evo_4">
-随着<span class="all_c">小粉红</span>被五个五个地吃掉，<span class="all_d">老油条</span>越来越多...
+随着<span class="all_c">圣母</span>被五个五个地吃掉，<span class="all_d">老油条</span>越来越多...
 </p>
 
 <p id="evo_5">
-现在，<span class="all_c">小粉红</span>们全部被吃掉了。不过，等等...
+现在，<span class="all_c">圣母</span>们全部被吃掉了。不过，等等...
 </p>
 
 <p id="evo_6">
-对啦：<span class="all_d">老油条</span>作茧自缚，变成了受害者！他们剥削完了天真无邪的<span class="all_c">小粉红</span>之后，不得不独自面对<span class="tft">复读机</span>了。<span class="tft">复读机</span>们虽然人很好，但是他们并不傻。
+对啦：<span class="all_d">老油条</span>作茧自缚，变成了受害者！他们剥削完了天真无邪的<span class="all_c">圣母</span>之后，不得不独自面对<span class="tft">复读机</span>了。<span class="tft">复读机</span>们虽然人很好，但是他们并不傻。
 </p>
 
 <p id="evo_7">
@@ -452,7 +452,7 @@ which, uh, could be worse!
 ...<span class="tft">复读机</span>继承了地球。
 </p>
 <p id="evo_9_all_c">
-好吧，尽管你猜错了——天真善良的<span class="all_c">小粉红</span>被从一开始就注定在劫难逃——最终，一种聪明的善良蔓延到了整个地球，<span class="all_d">老油条</span>也灰飞烟灭了。
+好吧，尽管你猜错了——天真善良的<span class="all_c">圣母</span>被从一开始就注定在劫难逃——最终，一种聪明的善良蔓延到了整个地球，<span class="all_d">老油条</span>也灰飞烟灭了。
 </p>
 <p id="evo_9_all_d">
 虽然短期内，你是对的——<span class="all_d">老油条</span>确实赢了前几场，但最终我们看到，当他残酷剥削的本质暴露无遗的同时，也不可避免地跌入了深渊。
@@ -507,7 +507,7 @@ which, uh, could be worse!
 <!-- - - - - - - - - - - - - - - - - -->
 
 <p id="distrust_1">
-在一切变得糟糕之前，我们先来看，我们先来看看好的一面！这是一个充满了<span class="all_c">小粉红</span>的世界，里面只有一个<span class="all_d">老油条</span>和一个<span class="tft">复读机</span>。
+在一切变得糟糕之前，我们先来看，我们先来看看好的一面！这是一个充满了<span class="all_c">圣母</span>的世界，里面只有一个<span class="all_d">老油条</span>和一个<span class="tft">复读机</span>。
 <br><br>
 用右边的这些按钮来<b>开始</b>快速模拟，或者<b>一步一步</b>地来，以及<b>重新</b>开始。 &rarr;
 </p>
@@ -636,7 +636,7 @@ which, uh, could be worse!
 </p>
 
 <p id="noise_evo_1">
-现在场上有十几个<span class="all_c">小粉红</span>，对阵我们的老冠军，公平的<span class="tft">复读机</span>，以及我们的三个新角色：宽容的<span class="tf2t">复读鸭</span>，迟钝的<span class="pavlov">一根筋</span>，还有傻傻的<span class="random">胡乱来</span>。
+现在场上有十几个<span class="all_c">圣母</span>，对阵我们的老冠军，公平的<span class="tft">复读机</span>，以及我们的三个新角色：宽容的<span class="tf2t">复读鸭</span>，迟钝的<span class="pavlov">一根筋</span>，还有傻傻的<span class="random">胡乱来</span>。
 <br><br>
 每一轮比赛中，玩家们都会有一个很小的概率会犯错误（假设是 5% 吧）。你觉得这次谁又会笑到最后呢？
 <b>仔细想想，然后做出你的选择：</b>
@@ -653,14 +653,14 @@ which, uh, could be worse!
 </p>
 <p id="noise_evo_2_2">
 <span class="pavlov">一根筋</span>取得了胜利！
-这是因为<span class="pavlov">一根筋</span>实际上具备剥削<span class="all_c">小粉红</span>的能力。他们都以「合作」开局，但是一旦<span class="pavlov">一根筋</span>犯了错，欺骗了对方，就会一直欺骗下去，因为<span class="all_c">小粉红</span><b>永远不会反击</b>。
+这是因为<span class="pavlov">一根筋</span>实际上具备剥削<span class="all_c">圣母</span>的能力。他们都以「合作」开局，但是一旦<span class="pavlov">一根筋</span>犯了错，欺骗了对方，就会一直欺骗下去，因为<span class="all_c">圣母</span><b>永远不会反击</b>。
 </p>
 <p id="noise_evo_2_2_btn">
 现在我们来试着...
 </p>
 
 <p id="noise_evo_3">
-...把占人数一半的<span class="all_c">小粉红</span>用<span class="all_d">老油条</span>替换掉，其他的都不变。这是一个一点儿也不宽容，充满了恶意的环境。
+...把占人数一半的<span class="all_c">圣母</span>用<span class="all_d">老油条</span>替换掉，其他的都不变。这是一个一点儿也不宽容，充满了恶意的环境。
 <br><br>
 现在你觉得谁会赢了呢？<b>想清楚，然后做出你的选择：</b>
 </p>


### PR DESCRIPTION
At now time, the word "粉红" is more used to indicate "CCP supporters", so I suggested to use the word "圣母" instead

就当下的情况, "粉红"一词更多地用来表示“中共支持者”, 与项目原意不符, 所以建议用“圣母”一词替代